### PR TITLE
services: move get_params method to services base module

### DIFF
--- a/libsaas/services/base.py
+++ b/libsaas/services/base.py
@@ -24,6 +24,29 @@ def wrap(wrapper, wrapped):
     return update_wrapper(wrapper, wrapped)
 
 
+def serialize_param(val):
+    if isinstance(val, bool):
+        return 'true' if val else 'false'
+    return val
+
+
+def get_params(param_names, param_store):
+    """
+    Return a dictionary suitable to be used as params in a libsaas.http.Request
+    object.
+
+    Arguments are a tuple of parameter names and a dictionary mapping those
+    names to parameter values. This is useful for constructs like
+
+    def apifunc(self, p1, p2, p3=None):
+        params = get_params(('p1', 'p2', 'p3'), locals())
+
+    which will extract parameters from the called method's environment.
+    """
+    return dict((name, serialize_param(param_store[name])) for name in param_names
+                if param_store.get(name) is not None)
+
+
 class MethodNotSupported(NotImplementedError):
     """
     This resource does not implement the method.

--- a/libsaas/services/github/forks.py
+++ b/libsaas/services/github/forks.py
@@ -23,7 +23,7 @@ class Forks(resource.GitHubResource):
         :var per_page: The amount of results per page.
         :vartype per_page: int
         """
-        params = resource.get_params(('sort', 'page', 'per_page'), locals())
+        params = base.get_params(('sort', 'page', 'per_page'), locals())
         request = http.Request('GET', self.get_url(), params)
 
         return request, parsers.parse_json

--- a/libsaas/services/github/gists.py
+++ b/libsaas/services/github/gists.py
@@ -17,7 +17,7 @@ class GistComments(GistCommentsBase):
     @base.apimethod
     def get(self, format=None, page=None, per_page=None):
         url = self.get_url()
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         headers = resource.mimetype_accept(format)
 
         return http.Request('GET', url, params, headers), parsers.parse_json
@@ -28,7 +28,7 @@ class GistComment(GistCommentsBase):
     @base.apimethod
     def get(self, format=None, page=None, per_page=None):
         url = self.get_url()
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         headers = resource.mimetype_accept(format)
 
         return http.Request('GET', url, params, headers), parsers.parse_json
@@ -44,7 +44,7 @@ class Gists(resource.GitHubResource):
         Fetch public gists. The parameters are the same as for `get`.
         """
         url = '{0}/public'.format(self.get_url())
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
 
         return http.Request('GET', url, params), parsers.parse_json
 
@@ -55,7 +55,7 @@ class Gists(resource.GitHubResource):
         same as for `get`.
         """
         url = '{0}/starred'.format(self.get_url())
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
 
         return http.Request('GET', url, params), parsers.parse_json
 

--- a/libsaas/services/github/issues.py
+++ b/libsaas/services/github/issues.py
@@ -20,7 +20,7 @@ class Issues(resource.GitHubResource):
         http://developer.github.com/v3/issues/#list-issues.
         """
         url = self.get_url()
-        params = resource.get_params(
+        params = base.get_params(
             ('filter', 'state', 'labels', 'sort', 'direction',
              'since', 'page', 'per_page'), locals())
 
@@ -136,7 +136,7 @@ class RepoIssues(RepoIssuesBase):
         http://developer.github.com/v3/issues/#list-issues-for-a-repository
         """
         url = self.get_url()
-        params = resource.get_params(
+        params = base.get_params(
             ('milestone', 'state', 'assignee', 'mentioned', 'labels', 'sort',
              'direction', 'since', 'page', 'per_page'), locals())
 

--- a/libsaas/services/github/labels.py
+++ b/libsaas/services/github/labels.py
@@ -33,7 +33,7 @@ class IssueLabelsBase(LabelsBase):
     @base.apimethod
     def get(self, page=None, per_page=None):
         self.require_collection()
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         request = http.Request('GET', self.get_url(), params)
 
         return request, parsers.parse_json

--- a/libsaas/services/github/milestones.py
+++ b/libsaas/services/github/milestones.py
@@ -38,7 +38,7 @@ class Milestones(MilestonesBase):
         http://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository.
         """
         url = self.get_url()
-        params = resource.get_params(
+        params = base.get_params(
             ('state', 'sort', 'direction', 'page', 'per_page'), locals())
 
         return http.Request('GET', url, params), parsers.parse_json

--- a/libsaas/services/github/repocommits.py
+++ b/libsaas/services/github/repocommits.py
@@ -23,7 +23,7 @@ class RepoCommitsComment(RepoCommitsCommentsBase):
             `html` or `full`. For details on formats, see
             http://developer.github.com/v3/mime/#comment-body-properties.
         """
-        params = resource.get_params(('format', ), locals())
+        params = base.get_params(('format', ), locals())
 
         return http.Request('GET', self.get_url(), params), parsers.parse_json
 
@@ -40,7 +40,7 @@ class RepoCommitsComments(RepoCommitsCommentsBase):
             http://developer.github.com/v3/mime/#comment-body-properties.
         """
         url = self.get_url()
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         headers = resource.mimetype_accept(format)
 
         return http.Request('GET', url, params, headers), parsers.parse_json
@@ -75,7 +75,7 @@ class RepoCommits(base.HierarchicalResource):
             file path.
         :vartype path: str
         """
-        params = resource.get_params(
+        params = base.get_params(
             ('sha', 'path', 'page', 'per_page'), locals())
         url = '{0}/{1}'.format(self.parent.get_url(), self.path)
 

--- a/libsaas/services/github/repos.py
+++ b/libsaas/services/github/repos.py
@@ -17,7 +17,7 @@ class Repos(resource.GitHubResource):
         :var type: What type of repos to fetch. For details of allowed values,
             see http://developer.github.com/v3/repos/#list-user-repositories.
         """
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         params['type'] = type
         request = http.Request('GET', self.get_url(), params)
 
@@ -33,7 +33,7 @@ class RepoCollaborators(base.Resource):
 
     @base.apimethod
     def get(self, page=None, per_page=None):
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         request = http.Request('GET', self.get_url(), params)
 
         return request, parsers.parse_json

--- a/libsaas/services/github/resource.py
+++ b/libsaas/services/github/resource.py
@@ -9,29 +9,6 @@ def mimetype_accept(format):
     return {'Accept': mimetype}
 
 
-def serialize_param(val):
-    if isinstance(val, bool):
-        return 'true' if val else 'false'
-    return val
-
-
-def get_params(param_names, param_store):
-    """
-    Return a dictionary suitable to be used as params in a libsaas.http.Request
-    object.
-
-    Arguments are a tuple of parameter names and a dictionary mapping those
-    names to parameter values. This is useful for constructs like
-
-    def apifunc(self, p1, p2, p3=None):
-        params = get_params(('p1', 'p2', 'p3'), locals())
-
-    which will extract parameters from the called method's environment.
-    """
-    return dict((name, serialize_param(param_store[name])) for name in param_names
-                if param_store.get(name) is not None)
-
-
 def parse_boolean(body, code, headers):
     # The boolean value endpoints respond with 204 if the response is true and
     # 404 if it is not.
@@ -58,7 +35,7 @@ class GitHubResource(base.RESTResource):
             maximum is 100. If left as `None`, 30 objects are returned.
         :vartype per_page: int
         """
-        params = get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         request = http.Request('GET', self.get_url(), params)
 
         return request, parsers.parse_json

--- a/libsaas/services/github/users.py
+++ b/libsaas/services/github/users.py
@@ -16,7 +16,7 @@ class UserRepos(resource.GitHubResource):
         :var type: What type of repos to fetch. For details of allowed values,
             see http://developer.github.com/v3/repos/#list-user-repositories.
         """
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
         params['type'] = type
         request = http.Request('GET', self.get_url(), params)
 
@@ -77,7 +77,7 @@ class UsersBase(resource.GitHubResource):
         Fetch the followers of this user.
         """
         url = '{0}/{1}'.format(self.get_url(), 'followers')
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
 
         return http.Request('GET', url, params), parsers.parse_json
 
@@ -87,7 +87,7 @@ class UsersBase(resource.GitHubResource):
         Fetch users that this user is following.
         """
         url = '{0}/{1}'.format(self.get_url(), 'following')
-        params = resource.get_params(('page', 'per_page'), locals())
+        params = base.get_params(('page', 'per_page'), locals())
 
         return http.Request('GET', url, params), parsers.parse_json
 


### PR DESCRIPTION
Because get_params method will be really useful when integrating
new services, we've moved it to services base module.
