### PR TITLE
intercom: add support for intercom.io

### DIFF
--- a/libsaas/services/intercom/__init__.py
+++ b/libsaas/services/intercom/__init__.py
@@ -1,0 +1,1 @@
+from .service import Intercom

--- a/libsaas/services/intercom/resource.py
+++ b/libsaas/services/intercom/resource.py
@@ -1,0 +1,173 @@
+from libsaas import http, parsers
+from libsaas.services import base
+
+
+class IntercomResource(base.RESTResource):
+
+    def get_url(self):
+        return '{0}/{1}'.format(self.parent.get_url(), self.path)
+
+
+class UserBase(IntercomResource):
+
+    path = 'users'
+
+    def delete(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+
+class Users(UserBase):
+
+    @base.apimethod
+    def get(self, page=None, per_page=None):
+        """
+        Fetch all of the objects.
+
+        :var page: The page that should be returned. If left as `None`,
+            first page are returned.
+        :vartype page: int
+
+        :var per_page: How many objects should be returned. The
+            maximum is 500. If left as `None`, 500 objects are returned.
+        :vartype per_page: int
+        """
+        params = base.get_params(('page', 'per_page'), locals())
+        request = http.Request('GET', self.get_url(), params)
+
+        return request, parsers.parse_json
+
+    @base.apimethod
+    def update(self, obj):
+        """
+        Update this resource.
+
+        :var obj: a Python object representing the updated resource, usually in
+            the same format as returned from `get`. Refer to the upstream
+            documentation for details.
+        """
+        request = http.Request('PUT', self.get_url(), self.wrap_object(obj))
+
+        return request, parsers.parse_json
+
+
+class User(UserBase):
+
+    def create(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    @base.apimethod
+    def get(self, user_id=None, email=None):
+        """
+        Fetch the object's data.
+
+        :var user_id: The user_id of the user that should be returned.
+            Required if no email.
+        :vartype user_id: int
+
+        :var email: The email of the user that should be returned.
+            Required if no user_id.
+        :vartype email: str
+        """
+        if not user_id and not email:
+           raise TypeError('get() must be passed at least one '
+                           'of user_id, email')
+
+        params = base.get_params(('user_id', 'email'), locals())
+        request = http.Request('GET', self.get_url(), params)
+
+        return request, parsers.parse_json
+
+
+class Impressions(IntercomResource):
+
+    path = 'users/impressions'
+
+    def get(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def delete(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+
+class MessageThreadBase(IntercomResource):
+
+    path = 'users/message_threads'
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def delete(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+
+class MessageThreads(MessageThreadBase):
+
+    @base.apimethod
+    def get(self, user_id=None, email=None):
+        """
+        Fetch all of the objects for the user.
+
+        :var user_id: The user_id of the user which messages should be
+            returned. Required if no email.
+        :vartype user_id: int
+
+        :var email: The email of the user which messages that should be
+            returned. Required if no user_id.
+        :vartype email: str
+        """
+        if not user_id and not email:
+           raise TypeError('get() must be passed at least one '
+                           'of user_id, email')
+
+        params = base.get_params(('user_id', 'email'), locals())
+        request = http.Request('GET', self.get_url(), params)
+
+        return request, parsers.parse_json
+
+    @base.apimethod
+    def reply(self, obj):
+        """
+        Reply to a message thread from an admin from a user
+        """
+        request = http.Request('PUT', self.get_url(), self.wrap_object(obj))
+
+        return request, parsers.parse_json
+
+
+class MessageThread(MessageThreadBase):
+
+    @base.apimethod
+    def get(self, thread_id, user_id=None, email=None):
+        """
+        Fetch all a single object.
+
+        :var thread_id: The thread_id of the message that should be returned.
+        :vartype thread_id: int
+
+        :var user_id: The user_id of the user which message should be returned.
+            Required if no email.
+        :vartype user_id: int
+
+        :var email: The email of the user which message that should be
+            returned. Required if no user_id.
+        :vartype email: str
+        """
+        if not user_id and not email:
+           raise TypeError('get() must be passed at least one '
+                           'of user_id, email')
+
+        params = base.get_params(('user_id', 'email'), locals())
+        params['thread_id'] = thread_id
+        request = http.Request('GET', self.get_url(), params)
+
+        return request, parsers.parse_json
+
+
+    def create(self, *args, **kwargs):
+        raise base.MethodNotSupported()

--- a/libsaas/services/intercom/service.py
+++ b/libsaas/services/intercom/service.py
@@ -1,0 +1,68 @@
+import json
+
+from libsaas import http
+
+from libsaas.filters import auth
+from libsaas.services import base
+
+from . import resource
+
+
+class Intercom(base.Resource):
+    """
+    """
+    def __init__(self, app_id, api_key):
+        """
+        Create a Intercom service.
+
+        :var app_id: The APP identifier.
+        :vartype app_id: str
+        :var api_key: The API key.
+        :vartype api_key: str
+        """
+        self.apiroot = 'https://api.intercom.io/v1'
+
+        self.add_filter(auth.BasicAuth(app_id, api_key))
+        self.add_filter(self.use_json)
+
+    def get_url(self):
+        return self.apiroot
+
+    def use_json(self, request):
+        if request.method.upper() not in http.URLENCODE_METHODS:
+            request.params = json.dumps(request.params)
+
+    @base.resource(resource.Users)
+    def users(self):
+        """
+        Return the resource corresponding to all users.
+        """
+        return resource.Users(self)
+
+    @base.resource(resource.User)
+    def user(self):
+        """
+        Return the resource corresponding to a single user.
+        """
+        return resource.User(self)
+
+    @base.resource(resource.Impressions)
+    def impressions(self):
+        """
+        Return the resource corresponding to all impressions.
+        """
+        return resource.Impressions(self)
+
+    @base.resource(resource.MessageThreads)
+    def message_threads(self):
+        """
+        Return the resource corresponding to all message threads.
+        """
+        return resource.MessageThreads(self)
+
+    @base.resource(resource.MessageThread)
+    def message_thread(self):
+        """
+        Return the resource corresponding to a single message thread.
+        """
+        return resource.MessageThread(self)

--- a/test/test_intercom.py
+++ b/test/test_intercom.py
@@ -1,0 +1,103 @@
+import json
+import unittest
+
+from libsaas.executors import test_executor
+from libsaas.services import intercom
+from libsaas.services.base import MethodNotSupported
+
+
+class IntercomTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.executor = test_executor.use()
+        self.executor.set_response(b'{}', 200, {})
+
+        self.service = intercom.Intercom('my-app-id', 'my-api-key')
+
+    def expect(self, method=None, uri=None, params=None, headers=None):
+        if method:
+            self.assertEqual(method, self.executor.request.method)
+        if uri:
+            self.assertEqual(self.executor.request.uri,
+                              'https://api.intercom.io/v1' + uri)
+        if params:
+            self.assertEqual(self.executor.request.params, params)
+        if headers:
+            self.assertEqual(self.executor.request.headers, headers)
+
+    def test_users(self):
+        with self.assertRaises(MethodNotSupported):
+            self.service.users().delete()
+
+        self.service.users().get()
+        self.expect('GET', '/users', {})
+        self.service.users().get(per_page=3)
+        self.expect('GET', '/users', {'per_page': 3})
+        self.service.users().get(page=3)
+        self.expect('GET', '/users', {'page': 3})
+
+        user = {'user': 'x'}
+        self.service.users().create(user)
+        self.expect('POST', '/users', json.dumps(user))
+        self.service.users().update(user)
+        self.expect('PUT', '/users', json.dumps(user))
+
+        with self.assertRaises(TypeError):
+            self.service.user().get()
+
+        with self.assertRaises(MethodNotSupported):
+            self.service.user().create()
+            self.service.user().update()
+            self.service.user().delete()
+
+        self.service.user().get(user_id=1)
+        self.expect('GET', '/users', {'user_id': 1})
+        self.service.user().get(email='name@domain.com')
+        self.expect('GET', '/users', {'email': 'name@domain.com'})
+
+    def test_impressions(self):
+        with self.assertRaises(MethodNotSupported):
+            self.service.impressions().get()
+            self.service.impressions().update()
+            self.service.impressions().delete()
+
+        impression = {'impression': 'x'}
+        self.service.impressions().create(impression)
+        self.expect('POST', '/users/impressions', json.dumps(impression))
+
+    def test_messages(self):
+        with self.assertRaises(MethodNotSupported):
+            self.service.message_threads().update()
+            self.service.message_threads().delete()
+
+        with self.assertRaises(TypeError):
+            self.service.message_threads().get()
+
+        self.service.message_threads().get(user_id=1)
+        self.expect('GET', '/users/message_threads', {'user_id': 1})
+        self.service.message_threads().get(email='name@domain.com')
+        self.expect('GET', '/users/message_threads',
+                    {'email': 'name@domain.com'})
+
+        message_thread = {'message_thread': 'x'}
+        self.service.message_threads().create(message_thread)
+        self.expect('POST', '/users/message_threads',
+                    json.dumps(message_thread))
+        self.service.message_threads().reply(message_thread)
+        self.expect('PUT', '/users/message_threads',
+                    json.dumps(message_thread))
+
+        with self.assertRaises(MethodNotSupported):
+            self.service.message_thread().create()
+            self.service.message_thread().update()
+            self.service.message_thread().delete()
+
+        with self.assertRaises(TypeError):
+            self.service.message_thread().get(1234)
+
+        self.service.message_thread().get(1234, user_id=1)
+        self.expect('GET', '/users/message_threads',
+                    {'thread_id': 1234, 'user_id': 1})
+        self.service.message_thread().get(1234, email='name@domain.com')
+        self.expect('GET', '/users/message_threads',
+                    {'thread_id': 1234, 'email': 'name@domain.com'})


### PR DESCRIPTION
Adding support for intercom.io API:
- Create, update and list users.
- Create a new impression.
- Create, update and list messages.
