### PR TITLE
Allow arrays (lists) properties

### DIFF
--- a/libsaas/port.py
+++ b/libsaas/port.py
@@ -43,7 +43,7 @@ def to_u(val, encoding='utf-8'):
     Take a number, text (unicode) or binary value and return unicode. Binary
     values are decoded using the provided encoding.
     """
-    if isinstance(val, text_type):
+    if isinstance(val, text_type) or isinstance(val, list):
         return val
     elif isinstance(val, numeric_types):
         return text_type(val)


### PR DESCRIPTION
I tried to send a property as a list data-type in Mixpanel. See:

https://mixpanel.com/docs/properties-or-segments/property-data-types

But I was getting an error:

AttributeError: 'list' object has no attribute 'decode'

This pull request fixes libsaas to be able to bypass a python list type object when encoding property values before converting the payload to JSON.

Cheers!
