### PR TITLE
stripe: fix resources due to Stripe's new API

### DIFF
--- a/libsaas/services/stripe/balance_history.py
+++ b/libsaas/services/stripe/balance_history.py
@@ -1,0 +1,17 @@
+from libsaas.services import base
+
+from . import resource
+
+
+class BalanceHistory(resource.ListResourceMixin, resource.StripeResource):
+
+    path = 'balance/history'
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def create(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def delete(self, *args, **kwargs):
+        raise base.MethodNotSupported()

--- a/libsaas/services/stripe/customers.py
+++ b/libsaas/services/stripe/customers.py
@@ -4,11 +4,17 @@ from libsaas import parsers, http
 from . import resource
 
 
-class SubscriptionResource(resource.StripeResource):
+class SubscriptionsResource(resource.StripeResource):
 
-    path = 'subscription'
+    path = 'subscriptions'
 
     def create(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def delete(self, *args, **kwargs):
         raise base.MethodNotSupported()
 
     @base.apimethod
@@ -19,6 +25,9 @@ class SubscriptionResource(resource.StripeResource):
         request = http.Request('GET', self.get_url())
 
         return request, parsers.parse_json
+
+
+class SubscriptionResource(SubscriptionsResource):
 
     @base.apimethod
     def update(self, obj):
@@ -76,12 +85,23 @@ class Customer(CustomersBaseResource):
     def create(self, *args, **kwargs):
         raise base.MethodNotSupported()
 
+    @base.resource(SubscriptionsResource)
+    def subscriptions(self):
+        """
+        Return the resource corresponding to the customer's subscriptions.
+        """
+        return SubscriptionsResource(self)
+
     @base.resource(SubscriptionResource)
-    def subscription(self):
+    def subscription(self, subscription_id):
         """
-        Return the resource corresponding to the customer's subscription.
+        Return the resource corresponding to a single customer's subscription.
+
+        :var subscription_id: The subscription's id.
+        :vartype subscription_id: str
         """
-        return SubscriptionResource(self)
+        return SubscriptionResource(self, subscription_id)
+
 
     @base.resource(DiscountResource)
     def discount(self):
@@ -91,10 +111,34 @@ class Customer(CustomersBaseResource):
         return DiscountResource(self)
 
 
-class Customers(resource.ListResourceMixin, CustomersBaseResource):
+class Customers(CustomersBaseResource):
 
     def update(self, *args, **kwargs):
         raise base.MethodNotSupported()
 
     def delete(self, *args, **kwargs):
         raise base.MethodNotSupported()
+
+    @base.apimethod
+    def get(self, total_count=False, count=None, offset=None):
+        """
+        Fetch all of the objects.
+
+        :var total_count: Include the total count of all customers.
+        :vartype total_count: bool
+
+        :var count: A limit on the number of objects to be returned.
+            Count can range between 1 and 100 objects.
+        :vartype count: int
+
+        :var offset: An offset into your object array. The API will return
+            the requested number of objects starting at that offset.
+        :vartype offset: int
+        """
+        params = {'count': count, 'offset': offset}
+        if total_count:
+            params.update({'include[]': 'total_count'})
+        params = base.get_params(None, params)
+        request = http.Request('GET', self.get_url(), params)
+
+        return request, parsers.parse_json

--- a/libsaas/services/stripe/service.py
+++ b/libsaas/services/stripe/service.py
@@ -9,6 +9,7 @@ from .charges import Charges, Charge
 from .coupons import Coupons, Coupon
 from .customers import Customers, Customer
 from .invoices import Invoices, Invoice, InvoiceItems, InvoiceItem
+from .balance_history import BalanceHistory
 
 
 class Stripe(base.Resource):
@@ -146,3 +147,10 @@ class Stripe(base.Resource):
         Return the resource corresponding to a single invoiceitem.
         """
         return InvoiceItem(self, id)
+
+    @base.resource(BalanceHistory)
+    def balance_history(self):
+        """
+        Return the resource corresponding to the balance history.
+        """
+        return BalanceHistory(self)

--- a/test/test_stripe.py
+++ b/test/test_stripe.py
@@ -119,14 +119,20 @@ class StripeTestCase(unittest.TestCase):
         self.service.customer('123').delete()
         self.expect('DELETE', '/customers/123', {})
 
-        self.service.customer('123').subscription().get()
-        self.expect('GET', '/customers/123/subscription', {})
+        self.service.customer('123').subscriptions().get()
+        self.expect('GET', '/customers/123/subscriptions', {})
 
-        self.service.customer('123').subscription().update({'key': 'value'})
-        self.expect('POST', '/customers/123/subscription', {'key': 'value'})
+        self.service.customer('123').subscription('ducks').get()
+        self.expect('GET', '/customers/123/subscriptions/ducks', {})
 
-        self.service.customer('123').subscription().delete()
-        self.expect('DELETE', '/customers/123/subscription', {})
+        self.service.customer('123').subscription('ducks').update(
+            {'key': 'value'})
+        self.expect('POST', '/customers/123/subscriptions/ducks',
+            {'key': 'value'})
+
+        self.service.customer('123').subscription('ducks').delete()
+        self.expect('DELETE', '/customers/123/subscriptions/ducks',
+            {})
 
         self.service.customer('123').discount().delete()
         self.expect('DELETE', '/customers/123/discount', {})


### PR DESCRIPTION
Now a Stripe's customer can own many subscritions and the count field has been replace by total_count.
