### PR TITLE
Ducksboard password should be optional

### DIFF
--- a/libsaas/services/ducksboard/service.py
+++ b/libsaas/services/ducksboard/service.py
@@ -10,7 +10,7 @@ from . import resources, datasource
 class Ducksboard(base.Resource):
     """
     """
-    def __init__(self, apikey_or_username, password=None):
+    def __init__(self, apikey_or_username, password=''):
         """
         Create a Ducksboard service.
 


### PR DESCRIPTION
With the current version, when I want to create a `Ducksboard` instance, the password is mandatory.

This first snippet will fail, because the password is not provided (`None`):

``` python
from libsaas.services.ducksboard import Ducksboard
Ducksboard(API_KEY).user().get()
```

It raises an `AttributeError` when trying to decode the password (`None`), traceback:

``` python
/home/david/w/i/libsaas/libsaas/filters/auth.pyc in __call__(self, request)
     26         # in latin-1.
     27         auth = port.to_u('{0}:{1}').format(port.to_u(self.username),
---> 28                                            port.to_u(self.password))
     29         encoded = port.to_u(base64.b64encode(port.to_b(auth)), 'latin-1')
     30         header = 'Basic {0}'.format(encoded)

/home/david/w/i/libsaas/libsaas/port.pyc in to_u(val, encoding)
     49         return text_type(val)
     50 
---> 51     return val.decode(encoding)
     52 
     53 

AttributeError: 'NoneType' object has no attribute 'decode'
```

This second snippet does work, the only difference is that it provides an empty str (`''`) as the `password`:

``` python
from libsaas.services.ducksboard import Ducksboard
Ducksboard(API_KEY, '').user().get()
```

From reading the documentation I understand that the `password` parameter should be optional parameter, and the first snippet should work.

Note that my change only fixes this behaviour for the `Ducksboard` service. Maybe more services with optional password are affected by this bug, in that case maybe you should patch the `BasicAuth` filter.
