### PR TITLE
github: Added support for releases

### DIFF
--- a/libsaas/services/github/releases.py
+++ b/libsaas/services/github/releases.py
@@ -1,0 +1,48 @@
+from libsaas.services import base
+
+from . import resource
+
+
+class ReleaseAssetBase(resource.GitHubResource):
+
+    path = 'assets'
+
+
+class ReleaseAssets(ReleaseAssetBase):
+    def delete(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def create(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+
+class ReleaseAsset(ReleaseAssetBase):
+    def create(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+
+class ReleasesBase(resource.GitHubResource):
+
+    path = 'releases'
+
+
+class Releases(ReleasesBase):
+    def delete(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+    def update(self, *args, **kwargs):
+        raise base.MethodNotSupported()
+
+
+class Release(ReleasesBase):
+
+    @base.resource(ReleaseAssets)
+    def assets(self):
+        return ReleaseAssets(self)
+
+    @base.resource(ReleaseAsset)
+    def asset(self, asset_id):
+        return ReleaseAsset(self, asset_id)

--- a/libsaas/services/github/repos.py
+++ b/libsaas/services/github/repos.py
@@ -2,7 +2,7 @@ from libsaas import http, parsers
 from libsaas.services import base
 
 from . import resource
-from . import downloads, forks, issues, keys, labels, milestones, repocommits
+from . import downloads, forks, issues, keys, labels, milestones, releases, repocommits
 from . import repocontents, pullrequests
 
 
@@ -241,9 +241,23 @@ class Repo(resource.GitHubResource):
     @base.resource(downloads.Downloads)
     def downloads(self):
         """
-        Return a resource corresponding to all commits from this repo.
+        Return a resource corresponding to all downloads from this repo.
         """
         return downloads.Downloads(self)
+
+    @base.resource(releases.Release)
+    def release(self, release_id):
+        """
+        Return a resource corresponding to a single release in this repo.
+        """
+        return releases.Release(self, release_id)
+
+    @base.resource(releases.Releases)
+    def releases(self):
+        """
+        Return a resource corresponding to all releases from this repo.
+        """
+        return releases.Releases(self)
 
     @base.resource(forks.Forks)
     def forks(self):

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -381,6 +381,41 @@ class GithubTestCase(unittest.TestCase):
                           self.service.repo('myuser', 'myrepo')
                           .download(1).update, {'x': 'x'})
 
+    def test_releases(self):
+        self.service.repo('myuser', 'myrepo').releases().get()
+        self.expect('GET', '/repos/myuser/myrepo/releases')
+
+        self.service.repo('myuser', 'myrepo').release(1).get()
+        self.expect('GET', '/repos/myuser/myrepo/releases/1')
+
+        self.service.repo('myuser', 'myrepo').releases().create({'x': 'x'})
+        self.expect('POST', '/repos/myuser/myrepo/releases',
+                    json.dumps({'x': 'x'}))
+
+        self.service.repo('myuser', 'myrepo').release(1).update({'x': 'x'})
+        self.expect('PATCH', '/repos/myuser/myrepo/releases/1',
+                    json.dumps({'x': 'x'}))
+
+        self.service.repo('myuser', 'myrepo').release(1).delete()
+        self.expect('DELETE', '/repos/myuser/myrepo/releases/1')
+
+        self.service.repo('myuser', 'myrepo').release(1).assets().get()
+        self.expect('GET', '/repos/myuser/myrepo/releases/1/assets')
+
+        self.service.repo('myuser', 'myrepo').release(1).asset(1).get()
+        self.expect('GET', '/repos/myuser/myrepo/releases/1/assets/1')
+
+        self.service.repo('myuser', 'myrepo').release(1).asset(1).update({'x': 'x'})
+        self.expect('PATCH', '/repos/myuser/myrepo/releases/1/assets/1',
+                    json.dumps({'x': 'x'}))
+
+        self.service.repo('myuser', 'myrepo').release(1).asset(1).delete()
+        self.expect('DELETE', '/repos/myuser/myrepo/releases/1/assets/1')
+
+        self.assertRaises(base.MethodNotSupported,
+                          self.service.repo('myuser', 'myrepo')
+                          .release(1).assets().create)
+
     def test_forks(self):
         self.service.repo('myuser', 'myrepo').forks().get(per_page=3)
         self.expect('GET', '/repos/myuser/myrepo/forks',


### PR DESCRIPTION
The downloads API is deprecated, the releases API should be used instead.

https://developer.github.com/v3/repos/downloads/
