### PR TITLE
fix quote for text with '/', such as branch 'dev/test'

### DIFF
--- a/libsaas/http.py
+++ b/libsaas/http.py
@@ -67,7 +67,7 @@ def quote_any(val):
     """
     Percent quote any value, be it binary, text or integer.
     """
-    return port.quote(port.to_b(val))
+    return port.quote(port.to_b(val), safe='')
 
 
 def urlencode_any(d):


### PR DESCRIPTION
When branch such as 'dev/test' use quote_any function, port.quote will let safe='/' as default. So branch whose text contains '/' will not work in restful api request `GET /projects/:id/repository/branches/:branch`
Just change `port.quote(port.to_b(val))` to `port.quote(port.to_b(val), safe='')` will be ok.